### PR TITLE
Bug when using setTime

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -172,8 +172,8 @@
 				o.meridiem = 'am';
 			}
 
-			if (o.hour < 10) o.hour = '0'+o.hour;
-			if (o.minute < 10) o.minute = '0'+o.minute;
+			if (o.hour < 10 && o.hour.length == 1) o.hour = '0'+o.hour;
+			if (o.minute < 10 && o.minute.length == 1) o.minute = '0'+o.minute;
 
 			o.daysOfWeekDisabled = o.daysOfWeekDisabled||[];
 			if (!$.isArray(o.daysOfWeekDisabled))


### PR DESCRIPTION
If you use:

setTime: "09:08"

Line 175 changes o.hour to 009
Line 176 changes o.minute to 008

Added some additional checks to allow the user to use:

setTime: "9:08"
or
setTime: "09:08"

(or setTime: "9:8 if they really wanted to)
